### PR TITLE
Add padding to content VStack

### DIFF
--- a/Placeholders/ContentView.swift
+++ b/Placeholders/ContentView.swift
@@ -27,6 +27,7 @@ struct ContentView: View {
                     .font(.body)
                     .foregroundColor(.secondary)
             }
+            .padding()
             .redacted(when: isLoading, redactionType: .customPlaceholder)
         }
         .padding()


### PR DESCRIPTION
In order to avoid a horizontal shift which hurts UX,
we add padding to the content VStack so the transition from the redacted view to the content view will be seamless.